### PR TITLE
Refactor cb

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    connect_box/cb_orig.py

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -94,7 +94,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
             config_en_set = m.bit(1) & io.config_en
 
-            config_en_set_and_addr_zero = config_en_set & config_addr_zero.O
+            config_en_set_and_addr_zero = config_en_set & config_addr_zero
 
             m.wire(config_en_set_and_addr_zero, config_cb.CE)
 

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -104,24 +104,18 @@ def define_cb(width, num_tracks, has_constant, default_value,
                                         has_ce=True,
                                         has_reset=True)
 
-            config_addr_zero = mantle.EQ(8)
-            m.wire(m.uint(0, 8), config_addr_zero.I0)
-            m.wire(config_addr_zero.I1, io.config_addr[24:32])
+            config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
 
-            config_en_set = mantle.And(2, 1)
-            m.wire(config_en_set.I0, m.uint(1, 1))
-            m.wire(config_en_set.I1[0], io.config_en)
+            config_en_set = 1 & io.config_en
 
-            config_en_set_and_addr_zero = mantle.And(2, 1)
-            m.wire(config_en_set_and_addr_zero.I0, config_en_set.O)
-            m.wire(config_en_set_and_addr_zero.I1[0], config_addr_zero.O)
+            config_en_set_and_addr_zero = config_en_set & config_addr_zero.O
 
-            m.wire(config_en_set_and_addr_zero.O[0], config_cb.CE)
+            m.wire(config_en_set_and_addr_zero, config_cb.CE)
 
             config_set_mux = mantle.Mux(height=2, width=CONFIG_DATA_WIDTH)
             m.wire(config_set_mux.I0, config_cb.O)
             m.wire(config_set_mux.I1, io.config_addr)
-            m.wire(config_set_mux.S, config_en_set_and_addr_zero.O[0])
+            m.wire(config_set_mux.S, config_en_set_and_addr_zero)
 
             m.wire(config_cb.RESET, io.reset)
             m.wire(config_cb.I, io.config_data)

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -10,10 +10,6 @@ def run_cmd(cmd):
         assert(res == 0)
 
 
-def power_log(x):
-        return 2**(math.ceil(math.log(x, 2)))
-
-
 def make_name(width, num_tracks, has_constant, default_value,
               feedthrough_outputs):
     return (f"connect_box_width_width_{width}"
@@ -118,7 +114,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
             m.wire(io.read_data, read_data)
 
-            pow_2_tracks = power_log(num_tracks)
+            pow_2_tracks = m.bitutils.clog2(num_tracks)
             print('# of tracks =', pow_2_tracks)
             output_mux = mantle.Mux(height=pow_2_tracks, width=width)
             m.wire(output_mux.S, config_cb.O[0:math.ceil(math.log(width, 2))])

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -111,6 +111,10 @@ def define_cb(width, num_tracks, has_constant, default_value,
     mux_sel_bit_count = m.bitutils.clog2(
         num_tracks - feedthrough_count + has_constant)
 
+    config_bit_count = mux_sel_bit_count + constant_bit_count
+
+    config_reg_width = int(math.ceil(config_bit_count / 32.0)*32)
+
     class ConnectBox(m.Circuit):
         name = make_name(width, num_tracks, has_constant, default_value,
                          feedthrough_outputs)
@@ -133,10 +137,6 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
         @classmethod
         def definition(io):
-
-            config_bit_count = mux_sel_bit_count + constant_bit_count
-
-            config_reg_width = int(math.ceil(config_bit_count / 32.0)*32)
 
             config_reg_reset_bit_vector = \
                 generate_reset_value(constant_bit_count, default_value,

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -1,8 +1,8 @@
 import os
 import math
-import mantle as mantle
 
 import magma as m
+import mantle as mantle
 
 
 def run_cmd(cmd):
@@ -64,9 +64,8 @@ def define_cb(width, num_tracks, has_constant, default_value,
             for i in range(0, len(feedthrough_outputs)):
                 feedthrough_count -= feedthrough_outputs[i] == '1'
 
-            mux_sel_bit_count = int(math.ceil(math.log(num_tracks -
-                                                       feedthrough_count +
-                                                       has_constant, 2)))
+            mux_sel_bit_count = m.bitutils.clog2(num_tracks - feedthrough_count
+                                                 + has_constant)
 
             constant_bit_count = has_constant * width
 
@@ -125,10 +124,10 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
             m.wire(io.read_data, read_data)
 
-            pow_2_tracks = m.bitutils.clog2(num_tracks)
+            pow_2_tracks = 2**m.bitutils.clog2(num_tracks)
             print('# of tracks =', pow_2_tracks)
             output_mux = mantle.Mux(height=pow_2_tracks, width=width)
-            m.wire(output_mux.S, config_cb.O[0:math.ceil(math.log(width, 2))])
+            m.wire(output_mux.S, config_cb.O[:m.bitutils.clog2(width)])
 
             # Note: Uncomment this line for select to make the unit test fail!
             # m.wire(output_mux.S, m.uint(0, math.ceil(math.log(width, 2))))

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -66,7 +66,7 @@ def generate_output_mux(num_tracks, feedthrough_outputs, has_constant, width,
     pow_2_tracks = 2**m.bitutils.clog2(num_tracks)
     print('# of tracks =', pow_2_tracks)
     output_mux = mantle.Mux(height=pow_2_tracks, width=width)
-    m.wire(output_mux.S, config_register.O[:m.bitutils.clog2(width)])
+    m.wire(output_mux.S, config_register.O[:m.bitutils.clog2(pow_2_tracks)])
 
     # This is only here because this is the way the switch box numbers
     # things.

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -64,8 +64,8 @@ def define_cb(width, num_tracks, has_constant, default_value,
             for i in range(0, len(feedthrough_outputs)):
                 feedthrough_count -= feedthrough_outputs[i] == '1'
 
-            mux_sel_bit_count = m.bitutils.clog2(num_tracks - feedthrough_count
-                                                 + has_constant)
+            mux_sel_bit_count = m.bitutils.clog2(
+                num_tracks - feedthrough_count + has_constant)
 
             constant_bit_count = has_constant * width
 
@@ -104,12 +104,10 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
             config_addr_zero = mantle.eq(m.uint(0, 8), io.config_addr[24:32])
 
-            config_en_set = m.bit(1) & io.config_en
+            m.wire(m.bit(1) & io.config_en & config_addr_zero, config_cb.CE)
 
-            config_en_set_and_addr_zero = config_en_set & config_addr_zero
-
-            m.wire(config_en_set_and_addr_zero, config_cb.CE)
-
+            # config_en_set = m.bit(1) & io.config_en
+            # config_en_set_and_addr_zero = config_en_set & config_addr_zero
             # TODO: (Lenny) Looks like this is unused?
             # config_set_mux = mantle.mux([config_cb.O, io.config_addr],
             #                             config_en_set_and_addr_zero)

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -64,8 +64,6 @@ def define_cb(width, num_tracks, has_constant, default_value,
             reset_val = num_tracks - feedthrough_count + has_constant - 1
             config_reg_reset_bit_vector = []
 
-            CONFIG_DATA_WIDTH = 32
-
             if (constant_bit_count > 0):
                 print('constant_bit_count =', constant_bit_count)
 

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -118,7 +118,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
             m.wire(config_cb.I, io.config_data)
 
             # Setting read data
-            read_data = mantle.mux([config_cb.O, m.uint(0, 32)],
+            read_data = mantle.mux([m.uint(0, 32), config_cb.O],
                                    mantle.eq(io.config_addr[24:32],
                                              m.uint(0, 8)))
 

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -24,10 +24,10 @@ def equals_cmp(a, b, width):
 
 def make_name(width, num_tracks, has_constant, default_value,
               feedthrough_outputs):
-    return (f"connect_box_width_width_{str(width)}"
-            f"_num_tracks_{str(num_tracks)}"
-            f"_has_constant{str(has_constant)}"
-            f"_default_value{str(default_value)}"
+    return (f"connect_box_width_width_{width}"
+            f"_num_tracks_{num_tracks}"
+            f"_has_constant{has_constant}"
+            f"_default_value{default_value}"
             f"_feedthrough_outputs_{feedthrough_outputs}")
 
 
@@ -46,7 +46,7 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
         for i in range(0, num_tracks):
             if (feedthrough_outputs[i] == '1'):
-                IO.append("in_" + str(i))
+                IO.append(f"in_{i}")
                 IO.append(m.In(m.Bits(width)))
 
         IO += [

--- a/connect_box/cb.py
+++ b/connect_box/cb.py
@@ -106,12 +106,6 @@ def define_cb(width, num_tracks, has_constant, default_value,
 
             m.wire(io.config_en & config_addr_zero, config_cb.CE)
 
-            # config_en_set = m.bit(1) & io.config_en
-            # config_en_set_and_addr_zero = config_en_set & config_addr_zero
-            # TODO: (Lenny) Looks like this is unused?
-            # config_set_mux = mantle.mux([config_cb.O, io.config_addr],
-            #                             config_en_set_and_addr_zero)
-
             m.wire(config_cb.RESET, io.reset)
             m.wire(config_cb.I, io.config_data)
 
@@ -125,9 +119,6 @@ def define_cb(width, num_tracks, has_constant, default_value,
             print('# of tracks =', pow_2_tracks)
             output_mux = mantle.Mux(height=pow_2_tracks, width=width)
             m.wire(output_mux.S, config_cb.O[:m.bitutils.clog2(width)])
-
-            # Note: Uncomment this line for select to make the unit test fail!
-            # m.wire(output_mux.S, m.uint(0, math.ceil(math.log(width, 2))))
 
             # This is only here because this is the way the switch box numbers
             # things.

--- a/connect_box/cb_orig.py
+++ b/connect_box/cb_orig.py
@@ -22,24 +22,17 @@ def equals_cmp(a, b, width):
         return eqC
 
 
-def make_name(width, num_tracks, has_constant, default_value,
-              feedthrough_outputs):
-    return (f"connect_box_width_width_{str(width)}"
-            f"_num_tracks_{str(num_tracks)}"
-            f"_has_constant{str(has_constant)}"
-            f"_default_value{str(default_value)}"
-            f"_feedthrough_outputs_{feedthrough_outputs}")
-
-
 @m.cache_definition
 def define_cb(width, num_tracks, has_constant, default_value,
               feedthrough_outputs):
-    CONFIG_DATA_WIDTH = 32
-    CONFIG_ADDR_WIDTH = 32
-
     class ConnectBox(m.Circuit):
-        name = make_name(width, num_tracks, has_constant, default_value,
-                         feedthrough_outputs)
+        name = (f"connect_box_width_width_{str(width)}"
+                f"_num_tracks_{str(num_tracks)}"
+                f"_has_constant{str(has_constant)}"
+                f"_default_value{str(default_value)}"
+                f"_feedthrough_outputs_{feedthrough_outputs}")
+        CONFIG_DATA_WIDTH = 32
+        CONFIG_ADDR_WIDTH = 32
 
         IO = ["clk", m.In(m.Clock),
               "reset", m.In(m.Reset)]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -31,7 +31,7 @@ def random_bv(width):
                          [(random_bv(16), 0)])
 # FIXME: this fails
 # @pytest.mark.parametrize('num_tracks', range(2,10))
-@pytest.mark.parametrize('num_tracks', [10])
+@pytest.mark.parametrize('num_tracks', [8, 10])
 def test_regression(default_value, num_tracks, has_constant):
     params = {
         "width": 16,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -19,6 +19,10 @@ def teardown_function():
     for item in glob.glob('genesis_*'):
         os.system(f"rm -r {item}")
 
+    build = make_relative("build")
+    for item in glob.glob(build):
+        if ".gitignore" in item:
+            os.system(f"rm -r {item}")
 
 def random_bv(width):
     return BitVector(random.randint(0, (1 << width) - 1), width)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -32,11 +32,16 @@ def random_bv(width):
 # FIXME: this fails
 # @pytest.mark.parametrize('num_tracks', range(2,10))
 @pytest.mark.parametrize('num_tracks', [8, 10])
-def test_regression(default_value, num_tracks, has_constant):
+@pytest.mark.parametrize('width', [7, 16])
+def test_regression(default_value, num_tracks, has_constant, width):
+    feedthrough_outputs = [str(random.randint(0, 1)) for x in
+                           range(num_tracks)]
+    # make sure at least 1 bit is set
+    feedthrough_outputs[random.randint(0, num_tracks - 1)] = 1
     params = {
-        "width": 16,
+        "width": width,
         "num_tracks": num_tracks,
-        "feedthrough_outputs": "1111101111",
+        "feedthrough_outputs": "".join(str(x) for x in feedthrough_outputs),
         "has_constant": has_constant,
         "default_value": default_value.as_int()
     }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -26,7 +26,7 @@ def random_bv(width):
 
 @pytest.mark.parametrize('default_value,has_constant',
                          # Test 10 random default values with has_constant
-                         [(random_bv(16), 1) for _ in range(10)] +
+                         [(random_bv(16), 1) for _ in range(2)] +
                          # include one test with no constant
                          [(random_bv(16), 0)])
 # FIXME: this fails

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -53,6 +53,11 @@ def test_regression(default_value, num_tracks, has_constant, width):
     os.system(f'coreir -i {json_file} -o {magma_verilog}')
 
     genesis_cb = define_cb_wrapper(**params, filename=make_relative("cb.vp"))
+    print("======= magma_cb =======")
+    print(magma_cb)
+    print("====== genesis_cb ======")
+    print(genesis_cb)
+    print("========================")
 
     genesis_verilog = "genesis_verif/cb.v"
     shutil.copy(genesis_verilog, make_relative("build"))


### PR DESCRIPTION
Here's a refactoring pass of the connection box generator. All tests still pass on Travis and kiwi (ncsim tests). 

Mainly decomposing into helper functions and using operators where possible.

We have to do a lot of parameter passing to the helper functions which is a bit verbose. We should consider some sort of class structure for generators where can have access to parameters in our method definitions. Alternatively we could define these functions within the `define_cb` closure, but at that point I think we should consider using a class.